### PR TITLE
Add django-rest-framework support

### DIFF
--- a/django_pycharm_breakpoint/django_app.py
+++ b/django_pycharm_breakpoint/django_app.py
@@ -22,6 +22,20 @@ class DjangoPycharmBreakpointConfig(AppConfig):
 
         exception.response_for_exception = monkey_patched_response_for_exception
 
+        try:
+            import rest_framework
+            from rest_framework.views import APIView
+        except ImportError:
+            pass
+        else:
+            APIView.original_handle_exception = APIView.handle_exception
+
+            def monkey_patched_handle_exception(self, exc):
+                breakpoint_on_exception()
+                return self.original_handle_exception(exc)
+
+            APIView.handle_exception = monkey_patched_handle_exception
+
 
 def breakpoint_on_exception():
     try:


### PR DESCRIPTION
Hey, I just found your tool, I love it. I just wanted to extend support for django-rest-framework.

DRF handles all exceptions that are thrown within the context of any APIView, making it difficult to debug them via the Pycharm debugger. I use the same approach as you did to patch the rest_framework.views.APIView.handle_exception method. I've tested this and it's working with DRF 3.10.3 and Django 3.0.8.